### PR TITLE
feat: migrate to yew 0.19

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "monaco"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Simon Berger <simon@siku2.io>"]
 edition = "2018"
 description = "Rust WASM bindings for the Monaco Editor"
@@ -28,7 +28,7 @@ yew-components = ["api", "yew"]
 js-sys = "0.3"
 paste = "1.0"
 wasm-bindgen = "0.2"
-yew = { version = "0.17", optional = true }
+yew = { version = "0.19", optional = true }
 
 [dependencies.web-sys]
 version = "0.3"


### PR DESCRIPTION
This migrates the yew component to yew 0.19. As this would be a breaking change, I incremented the version number to 0.3.

closes #11