### PR TITLE
Fix build script that build JS files.

### DIFF
--- a/build/justfile
+++ b/build/justfile
@@ -1,6 +1,6 @@
 # Build the Monaco Javascript files
 @build:
-    rm dist/*
+    -rm dist/*
     npm run build
 
 # Install the node dependencies


### PR DESCRIPTION
Result of `rm dist/*` command should be ignored.
During first build, `dist` directory does not exists, and thus build fails.