### PR TITLE
editor: add more Default for structs

### DIFF
--- a/src/sys/editor.rs
+++ b/src/sys/editor.rs
@@ -45,6 +45,9 @@ impl_default_empty_obj![
     IGlobalEditorOptions,
     IModelDecorationOptions,
     ISuggestOptions,
+    IEditorScrollbarOptions,
+    IEditorFindOptions,
+    IEditorMinimapOptions,
     IStandaloneEditorConstructionOptions,
 ];
 


### PR DESCRIPTION
These defaults impls are needed for some of the optional fields of
`IStandaloneEditorConstructionOptions`.