### PR TITLE
Allow full options on Editor

### DIFF
--- a/src/sys/editor.rs
+++ b/src/sys/editor.rs
@@ -1042,7 +1042,7 @@ extern "C" {
 #[wasm_bindgen]
 extern "C" {
     /// The options to create an editor.
-    #[derive(Debug)]
+    #[derive(Debug, PartialEq, Clone)]
     #[wasm_bindgen(extends = IEditorConstructionOptions, extends = IGlobalEditorOptions, extends = Object)]
     pub type IStandaloneEditorConstructionOptions;
     /// The initial model associated with this code editor.
@@ -2954,7 +2954,7 @@ extern "C" {
 #[wasm_bindgen]
 extern "C" {
     /// Configuration options for the editor.
-    #[derive(Debug)]
+    #[derive(Debug, PartialEq, Clone)]
     #[wasm_bindgen(extends = Object)]
     pub type IEditorOptions;
     /// This editor is used inside a diff editor.
@@ -3746,7 +3746,7 @@ extern "C" {
 
 #[wasm_bindgen]
 extern "C" {
-    #[derive(Debug)]
+    #[derive(Debug, PartialEq, Clone)]
     #[wasm_bindgen(extends = IEditorOptions, extends = Object)]
     pub type IEditorConstructionOptions;
     /// The initial editor dimension (to avoid measuring the container).

--- a/src/yew/mod.rs
+++ b/src/yew/mod.rs
@@ -1,17 +1,20 @@
 //! Monaco editor as a [Yew](https://yew.rs) component.
 //! Requires the "yew" feature.
-use crate::api::{CodeEditor as CodeEditorModel, CodeEditorOptions, TextModel};
+use crate::{
+    api::{CodeEditor as CodeEditorModel, TextModel},
+    sys::editor::IStandaloneEditorConstructionOptions,
+};
 use std::{cell::RefCell, mem, rc::Rc};
 use web_sys::HtmlElement;
 use yew::{html, html::Scope, Callback, Component, Context, Html, NodeRef, Properties};
 
 #[derive(Clone, Debug, PartialEq, Properties)]
-pub struct CodeEditorProps {
+pub struct CodeEditorProps<OPT: std::cmp::PartialEq + Clone + Into<IStandaloneEditorConstructionOptions> = IStandaloneEditorConstructionOptions> {
     #[prop_or_default]
     pub link: Option<CodeEditorLink>,
     /// Changing the options will cause the editor to be re-created.
     #[prop_or_default]
-    pub options: Option<Rc<CodeEditorOptions>>,
+    pub options: Option<OPT>,
     #[prop_or_default]
     pub model: Option<TextModel>,
     /// This could be called multiple times if the `options` field changes.
@@ -125,7 +128,7 @@ impl Component for CodeEditor {
             .expect("failed to resolve editor element");
 
         let props = ctx.props();
-        let editor = CodeEditorModel::create(&el, props.options.as_deref());
+        let editor = CodeEditorModel::create(&el, props.options.clone());
 
         if let Some(model) = &props.model {
             // initially we only update the model if it was actually given as a prop.


### PR DESCRIPTION
This would close https://github.com/siku2/rust-monaco/issues/20 & https://github.com/siku2/rust-monaco/issues/8

I tried to keep a bit more backward-compatibility relative to the proposal in https://github.com/siku2/rust-monaco/issues/20. But tbh I didn't understand the depth of the Borrows / Derefs.

Edit: after trying this for PRQL — ofc it breaks backward-compat because of the `Rc` change anyway. So if `CodeEditorProps` shouldn't be generic, lmk