### PR TITLE
Take a prop for classes in the Yew component instead of hard-coding styles

### DIFF
--- a/src/yew/mod.rs
+++ b/src/yew/mod.rs
@@ -6,7 +6,7 @@ use crate::{
 };
 use std::{cell::RefCell, mem, rc::Rc};
 use web_sys::HtmlElement;
-use yew::{html, html::Scope, Callback, Component, Context, Html, NodeRef, Properties};
+use yew::{html, html::Scope, Callback, Classes, Component, Context, Html, NodeRef, Properties};
 
 #[derive(Clone, Debug, PartialEq, Properties)]
 pub struct CodeEditorProps<OPT: std::cmp::PartialEq + Clone + Into<IStandaloneEditorConstructionOptions> = IStandaloneEditorConstructionOptions> {
@@ -21,6 +21,8 @@ pub struct CodeEditorProps<OPT: std::cmp::PartialEq + Clone + Into<IStandaloneEd
     /// You can use this to initialise the editor
     #[prop_or_default]
     pub on_editor_created: Callback<CodeEditorLink>,
+    #[prop_or_default]
+    pub classes: Classes,
 }
 
 /// CodeEditor component.
@@ -72,6 +74,7 @@ impl Component for CodeEditor {
             options,
             model,
             on_editor_created: _,
+            ..
         } = &ctx.props();
 
         let mut should_render = false;
@@ -106,10 +109,11 @@ impl Component for CodeEditor {
         should_render
     }
 
-    fn view(&self, _ctx: &Context<Self>) -> Html {
+    fn view(&self, ctx: &Context<Self>) -> Html {
         let Self {
             node_ref, editor, ..
         } = self;
+        let props = ctx.props();
 
         debug_assert!(
             editor.is_none(),
@@ -117,7 +121,7 @@ impl Component for CodeEditor {
         );
 
         html! {
-            <div ref={node_ref.clone()} style="width: 100%; height: 100%;" />
+            <div ref={node_ref.clone()} class={props.classes.clone()} />
         }
     }
 


### PR DESCRIPTION
Hard coded styles can mess up layouts when using the component. This PR removes the inline styles and replaces them with a `classes` prop