### PR TITLE
Fix (?) `CodeEditorLink`

### DIFF
--- a/src/yew/mod.rs
+++ b/src/yew/mod.rs
@@ -6,7 +6,7 @@ use crate::{
 };
 use std::{cell::RefCell, rc::Rc};
 use web_sys::HtmlElement;
-use yew::{html, html::Scope, Callback, Classes, Component, Context, Html, NodeRef, Properties};
+use yew::{html, Callback, Classes, Component, Context, Html, NodeRef, Properties};
 
 #[derive(Clone, Debug, PartialEq, Properties)]
 pub struct CodeEditorProps<OPT: std::cmp::PartialEq + Clone + Into<IStandaloneEditorConstructionOptions> = IStandaloneEditorConstructionOptions> {
@@ -25,14 +25,13 @@ pub struct CodeEditorProps<OPT: std::cmp::PartialEq + Clone + Into<IStandaloneEd
     pub classes: Classes,
 }
 
+type ModelCell = Rc<RefCell<Option<CodeEditorModel>>>;
+
 /// CodeEditor component.
-///
-/// Use the `link` prop to pass down a [`CodeEditorLink`] which can be used to
-/// access the [`CodeEditor`](CodeEditorModel).
 #[derive(Debug)]
 pub struct CodeEditor {
     node_ref: NodeRef,
-    editor: Option<CodeEditorModel>,
+    editor: ModelCell,
 }
 impl CodeEditor {
     fn emit_editor_created(&self, ctx: &Context<Self>) {
@@ -44,8 +43,7 @@ impl CodeEditor {
         // reuse the link we were given or create a new one
         let link = link
             .clone()
-            .unwrap_or_else(|| CodeEditorLink::new_connected(ctx.link().clone()));
-
+            .unwrap_or_else(|| CodeEditorLink::new_connected(self.editor.clone()));
         on_editor_created.emit(link);
     }
 }
@@ -54,13 +52,13 @@ impl Component for CodeEditor {
     type Properties = CodeEditorProps;
 
     fn create(ctx: &Context<Self>) -> Self {
+        let editor = ModelCell::default();
         if let Some(editor_link) = &ctx.props().link {
-            editor_link.connect(ctx.link().clone());
+            editor_link.connect(editor.clone());
         }
-
         Self {
             node_ref: NodeRef::default(),
-            editor: None,
+            editor,
         }
     }
 
@@ -78,7 +76,7 @@ impl Component for CodeEditor {
         if link != &old_props.link {
             // make sure to connect the new link to this component
             if let Some(link) = &link {
-                link.connect(ctx.link().clone());
+                link.connect(self.editor.clone());
             }
         }
         // changing options requires re-create
@@ -87,7 +85,7 @@ impl Component for CodeEditor {
         }
         // change the attached model
         if model != &old_props.model {
-            if let Some(editor) = &self.editor {
+            if let Some(editor) = &mut *self.editor.borrow_mut() {
                 match model {
                     Some(model) => editor.set_model(model),
                     None => {
@@ -100,7 +98,7 @@ impl Component for CodeEditor {
         if should_render {
             // if we're gonna re-create the editor we need to clean up the old one first so
             // as not to cause issues
-            self.editor = None;
+            self.editor.replace(None);
         }
 
         should_render
@@ -113,7 +111,7 @@ impl Component for CodeEditor {
         let props = ctx.props();
 
         debug_assert!(
-            editor.is_none(),
+            editor.borrow().is_none(),
             "previous editor must be disposed before re-creating"
         );
 
@@ -138,41 +136,36 @@ impl Component for CodeEditor {
             editor.set_model(model)
         }
 
-        self.editor = Some(editor);
+        self.editor.replace(Some(editor));
         self.emit_editor_created(ctx);
     }
 }
 
 /// Link to control a [`CodeEditor`].
 #[derive(Clone, Debug, Default)]
-pub struct CodeEditorLink(Rc<RefCell<Option<Scope<CodeEditor>>>>);
+pub struct CodeEditorLink(RefCell<ModelCell>);
+
 impl CodeEditorLink {
-    fn new_connected(link: Scope<CodeEditor>) -> Self {
-        Self(Rc::new(RefCell::new(Some(link))))
+    pub fn new() -> Self {
+        Self(RefCell::default())
     }
 
-    fn connect(&self, link: Scope<CodeEditor>) {
-        self.0.borrow_mut().replace(link);
+    fn new_connected(model_cell: ModelCell) -> Self {
+        Self(RefCell::new(model_cell))
     }
 
-    fn with_link<T>(&self, f: impl FnOnce(&Scope<CodeEditor>) -> T) -> Option<T> {
-        (*self.0.borrow()).as_ref().map(f)
-    }
-
-    fn with_component<T>(&self, f: impl FnOnce(&CodeEditor) -> T) -> Option<T> {
-        self.with_link(|link| link.get_component().as_deref().map(f))
-            .flatten()
+    fn connect(&self, model_cell: ModelCell) {
+        self.0.replace(model_cell);
     }
 
     /// Get access to the underlying [`CodeEditor`].
     /// The return value is `None` if the link isn't connected.
     pub fn with_editor<T>(&self, f: impl FnOnce(&CodeEditorModel) -> T) -> Option<T> {
-        self.with_component(|comp| comp.editor.as_ref().map(f))
-            .flatten()
+        self.0.borrow().borrow().as_ref().map(f)
     }
 }
 impl PartialEq for CodeEditorLink {
     fn eq(&self, other: &Self) -> bool {
-        Rc::ptr_eq(&self.0, &other.0)
+        Rc::ptr_eq(&self.0.borrow(), &other.0.borrow())
     }
 }


### PR DESCRIPTION
When attempting to use `CodeEditorLink::with_editor`, in my use-case the callback was never invoked, and `with_editor` would always return `None`. When printing the value of the link, I saw it *did* have a `Some(...)` in there, so I suspect something was up with the way `Rc` / borrows were used? I tried to understand exactly what's happening, but got lost in the `Scope` / `Rc` / `RefCell` soup. Another guess is that the `Scope` that got stored in the `Rc<RefCell>` on `CodeEditorLink` wasn't actually linked (heh) to the *real* scope, since it got a copy of the `Scope`.

I'm kinda experimenting my way through a fairly big design space, and I have *some* experience messing with `Rc` and friends, but I'm completely new to Yew, so I'll document my thought process so you can more easily tell me if / how I'm wrong.

See it in action:
* https://abesto.github.io/clox-rs/
* https://github.com/abesto/clox-rs/blob/def4bed61a1c1c6b5d84a67284549a6343c8cd06/web/src/main.rs

## Attempt 1

* We only ever store `CodeEditorModel` inside an `Rc<RefCell<Option<CodeEditorModel>>>`. This smart pointer gets cloned to each new `CodeEditorLink` (instead of storing some reference to a `Scope`). This makes it easy to reason about what's going on - exactly the data we need is passed around, and it has a single place of storage.
* I dropped the feature of allowing a `CodeEditorLink` to be passed in, for two reasons:
  * `CodeEditorLink` didn't expose a public constructor, and the `.0` field is private, so there is in fact no way (AFAICT) to create a `CodeEditorLink`. This means the feature ... never worked? I think?
  * `ctx.prop()` gives us an &-reference, so to update the data in the `CodeEditorLink` passed in via props, we need internal mutability, which complicates things further. Dropping this allows the implementation to be simple, and user code can still store the `CodeEditorLink` instance received in the `on_editor_created` callback.

This however has a drawback: if user code wants to store the `CodeEditorLink`, then (at least in functional components) we kinda enforce double-rendering at startup: there's no clean way of saying "re-render if the link changes, except the first time when I store some special `None` value in the state". So:

## Attempt 2

* Added a public constructor
* Re-added the `link` property
* Wrapped the data in `CodeEditorModel` into a `RefCell` to enable internal mutability (no need for another wrapping `Rc`)

This is close, but there's *still* double-rendering in some circumstances. The core problem is: we don't have anything in `CodeEditorLink` for a stable comparison across rendering passes, *only* the reference to the model. Since that changes once the editor is created, the `CodeEditorLink` is also considered to have changed.

I messed around with a synthetic id, but didn't manage to get the behavior I wanted; ended up using `TextModel` instead to get the text out of the editor.

Again, this is not perfect; in particular, if `on_editor_created` depends on the `CodeEditorLink`, then we get double-rendering. But I figure it's an improvement still, so submitting the PR.