### PR TITLE
build: fix a build warning about duplicate packages when using as git…

### DIFF
--- a/examples/yew_events_external/Cargo.toml
+++ b/examples/yew_events_external/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "yew_events"
+name = "yew_events_external"
 version = "0.1.0"
 edition = "2018"
 

--- a/examples/yew_events_keymapping/Cargo.toml
+++ b/examples/yew_events_keymapping/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "yew_events"
+name = "yew_events_keymapping"
 version = "0.1.0"
 edition = "2018"
 


### PR DESCRIPTION
… dependency

```
warning: skipping duplicate package `yew_events` found at `/home/user/.cargo/git/checkouts/rust-monaco-555a6769dedf399a/f913990/examples/yew_events_keymapping`
```